### PR TITLE
Sample rate for en-GB and session token support

### DIFF
--- a/lib/aws-signature-v4.js
+++ b/lib/aws-signature-v4.js
@@ -89,6 +89,9 @@ exports.createPresignedURL = function(method, host, path, service, payload, opti
   query['X-Amz-Date'] = toTime(options.timestamp);
   query['X-Amz-Expires'] = options.expires;
   query['X-Amz-SignedHeaders'] = exports.createSignedHeaders(options.headers);
+  if (options.sessionToken) {
+    query['X-Amz-Security-Token'] = options.sessionToken;
+  }
 
   var canonicalRequest = exports.createCanonicalRequest(method, path, query, options.headers, payload);
   var stringToSign = exports.createStringToSign(options.timestamp, options.region, service, canonicalRequest);

--- a/lib/main.js
+++ b/lib/main.js
@@ -81,7 +81,7 @@ function setLanguage() {
     if (languageCode == "en-US" || languageCode == "es-US")
         sampleRate = 44100;
     else
-        sampleRate = 16000;
+        sampleRate = 8000;
 }
 
 function setRegion() {


### PR DESCRIPTION
Issues #1 and #3 

* Changes sample rate for en-GB to 8000 so that the example will work while AWS investigate the issue internally.
* Extends the `createPresignedURL` function so that it handles session token. While these aren't used in the example. People looking to adapt the example for production use will likely want to provide credentials by some means other than direct user input and supporting session tokens is convenient for this use case. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
