### PR TITLE
Add MFA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
 
                 <label>Secret Key:</label>
                 <input type="password" id="secret_key" placeholder="SECRET KEY" value="" />
+                <label>Session Token (if using MFA):</label>
+                <input type="password" id="session_token" placeholder="SESSION TOKEN" value="" />
             </div>
             <div class="col">
                 <label>Language: </label>

--- a/lib/main.js
+++ b/lib/main.js
@@ -226,6 +226,7 @@ function createPresignedUrl() {
         crypto.createHash('sha256').update('', 'utf8').digest('hex'), {
             'key': $('#access_id').val(),
             'secret': $('#secret_key').val(),
+            'sessionToken': $('#session_token').val(),
             'protocol': 'wss',
             'expires': 15,
             'region': region,


### PR DESCRIPTION
*Description of changes:*
Accepts a Session Token alongside the Access ID and Secret Key fields so MFA-enabled accounts/users can use this sweet demo, too.

(My organization prohibits non-MFA account or user creation, so this stopped me for a bit. I set up a non-MFA user in my personal account to make sure that not providing a Session Token continued to work with these changes. It does!)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.