### PR TITLE
Add inputSampleRate for inputs greater than 44100

### DIFF
--- a/lib/audioUtils.js
+++ b/lib/audioUtils.js
@@ -1,5 +1,3 @@
-const inputSampleRate = 44100;
-
 export function pcmEncode(input) {
     var offset = 0;
     var buffer = new ArrayBuffer(input.length * 2);
@@ -11,7 +9,8 @@ export function pcmEncode(input) {
     return buffer;
 }
 
-export function downsampleBuffer(buffer, outputSampleRate = 16000) {
+export function downsampleBuffer(buffer, inputSampleRate = 44100, outputSampleRate = 16000) {
+        
     if (outputSampleRate === inputSampleRate) {
         return buffer;
     }
@@ -21,17 +20,25 @@ export function downsampleBuffer(buffer, outputSampleRate = 16000) {
     var result = new Float32Array(newLength);
     var offsetResult = 0;
     var offsetBuffer = 0;
+    
     while (offsetResult < result.length) {
+
         var nextOffsetBuffer = Math.round((offsetResult + 1) * sampleRateRatio);
+
         var accum = 0,
         count = 0;
-        for (var i = offsetBuffer; i < nextOffsetBuffer && i < buffer.length; i++) {
+        
+        for (var i = offsetBuffer; i < nextOffsetBuffer && i < buffer.length; i++ ) {
             accum += buffer[i];
             count++;
         }
+
         result[offsetResult] = accum / count;
         offsetResult++;
         offsetBuffer = nextOffsetBuffer;
-     }
-     return result;
+
+    }
+
+    return result;
+
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ const eventStreamMarshaller = new marshaller.EventStreamMarshaller(util_utf8_nod
 let languageCode;
 let region;
 let sampleRate;
+let inputSampleRate;
 let transcription = "";
 let socket;
 let micStream;
@@ -51,6 +52,11 @@ $('#start-button').click(function () {
 let streamAudioToWebSocket = function (userMediaStream) {
     //let's get the mic input from the browser, via the microphone-stream module
     micStream = new mic();
+
+    micStream.on("format", function(data) {
+        inputSampleRate = data.sampleRate;
+    });
+
     micStream.setStream(userMediaStream);
 
     // Pre-signed URLs are a way to authenticate a request (or WebSocket connection, in this case)
@@ -60,6 +66,8 @@ let streamAudioToWebSocket = function (userMediaStream) {
     //open up our WebSocket connection
     socket = new WebSocket(url);
     socket.binaryType = "arraybuffer";
+
+    let sampleRate = 0;
 
     // when we get audio data from the mic, send it to the WebSocket if possible
     socket.onopen = function() {
@@ -185,7 +193,7 @@ function convertAudioToBinaryMessage(audioChunk) {
         return;
 
     // downsample and convert the raw audio bytes to PCM
-    let downsampledBuffer = audioUtils.downsampleBuffer(raw, sampleRate);
+    let downsampledBuffer = audioUtils.downsampleBuffer(raw, inputSampleRate, sampleRate);
     let pcmEncodedBuffer = audioUtils.pcmEncode(downsampledBuffer);
 
     // add the right JSON headers and structure to the message


### PR DESCRIPTION
*Issue #, if available:* #21 

*Description of changes:*

![Screen Shot 2020-03-30 at 6 05 29 PM](https://user-images.githubusercontent.com/318295/77970383-b0404000-72b1-11ea-8128-3294af363f31.png)

Modifies `downsampleBuffer` to take `inputSampleRate` into account. Previously this was a fixed value that broke the stream whenever a high quality audio stream was supplied as input.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.